### PR TITLE
refactor: reducer 분할 및 유저 정보 저장

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -2,32 +2,42 @@ import React from "react";
 import './Navigation.css';
 import { AUTH_URL } from '../LoginKey';
 import { useSelector, useDispatch } from 'react-redux';
+import { logout } from "../redux/tokenReducer";
+import { clearMember } from "../redux/memberReducer";
+import { useNavigate } from "react-router-dom";
 
 function Navigation() {
-    const user = useSelector( (state) => state );
+    const member = useSelector(state => state.member);
     const dispatch = useDispatch();
+    const navigate = useNavigate();
 
-    function checkLogin (e) {
-        if(user.id === null){
+    const logoutDispatch = async () => {
+        dispatch(logout());
+        dispatch(clearMember())
+    };
+
+    function checkLogin(e) {
+        if (member.id === null) {
             const modal = document.getElementById("alert-modal");
             modal.style.display = "flex";
-        }    
-        else 
+        }
+        else
             window.location.href = `${e.target.value}`;
     }
-  
-    function changeLogin() {
-        if(user.id !== null){
-            if(window.confirm("로그아웃 하시겠습니까?")){
+
+    async function changeLogin() {
+        if (member.signed === true) {
+            if (window.confirm("로그아웃 하시겠습니까?")) {
                 alert("로그아웃이 완료되었습니다.\n비회원 상태에서는 일부 기능이 제한될 수 있습니다.");
-                dispatch({ type : '로그아웃' });
-                window.location.href = '/home';
+                await logoutDispatch();
+                // window.location.href = '/home';
+                navigate('/home');
             }
         }
-        else 
+        else
             window.location.href = AUTH_URL;
     }
-    
+
     function clickImg() {
         const modal = document.getElementById("my-modal");
         modal.style.display = (modal.style.display === "flex") ? "none" : "flex";
@@ -39,18 +49,18 @@ function Navigation() {
         document.body.style.overflow = "unset";
     }
 
-    return(
+    return (
         <>
             <nav className="navbar">
-                <a className="navLogo" href='/'> <img id="logoImg" alt="" src = "/img/naviLogo.png"/> </a>
-                
+                <a className="navLogo" href='/'> <img id="logoImg" alt="" src="/img/naviLogo.png" /> </a>
+
                 <div id="menu">
                     <button className="navItem" onClick={checkLogin} value="/create"> GAN 사진 변환 </button>
                     <a className="navItem" href='/home'> 미슐간 </a>
-                    
-                    { user.profileImage 
-                    ? <div id="img-wrapper"> <img src={user.profileImage} onClick={clickImg} alt=""/> </div> 
-                    : <a className="navItem" href={AUTH_URL}> 로그인 </a>
+
+                    {member.profileImage
+                        ? <div id="img-wrapper"> <img src={member.profileImage} onClick={clickImg} alt="" /> </div>
+                        : <a className="navItem" href={AUTH_URL}> 로그인 </a>
                     }
                 </div>
             </nav>
@@ -67,9 +77,9 @@ function Navigation() {
                         <p> 로그인이 필요한 서비스입니다 </p>
 
                         <div>
-                            <button id="kakaoLogin" onClick={() => {window.location.href={AUTH_URL};}}> <img src="/img/kakao.png" alt="" /> </button>
-                            <button id="googleLogin" onClick={() => {window.location.href={AUTH_URL};}}> <img src="/img/google.png" alt="" /> </button>
-                            <button id="naverLogin" onClick={() => {window.location.href={AUTH_URL};}}> <img src="/img/naver.png" alt="" /> </button>
+                            <button id="kakaoLogin" onClick={() => { window.location.href = { AUTH_URL }; }}> <img src="/img/kakao.png" alt="" /> </button>
+                            <button id="googleLogin" onClick={() => { window.location.href = { AUTH_URL }; }}> <img src="/img/google.png" alt="" /> </button>
+                            <button id="naverLogin" onClick={() => { window.location.href = { AUTH_URL }; }}> <img src="/img/naver.png" alt="" /> </button>
                         </div>
 
                         <div>

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -13,7 +13,7 @@ function GalleryRouter(){
         <Router>
             <Routes>
                 <Route exact path = "/login/oauth2/code/kakao" element = { <Login/> }/>
-                <Route exact path = "/join" element = { <Join/> }/>
+                <Route exact path = "/join/:initialName" element = { <Join/> }/>
                 <Route exact path = '/' element = { <Start/> }/>
                 <Route exact path = '/home' element = { <Home/> } />
                 <Route exact path = '/myPage' element = { <MyPage/> }/>

--- a/src/index.js
+++ b/src/index.js
@@ -8,44 +8,16 @@ import { persistStore, persistReducer } from 'redux-persist';
 import storageSession from 'redux-persist/lib/storage/session';
 import { applyMiddleware } from 'redux'; 
 import { PersistGate } from 'redux-persist/integration/react'; 
-import axios from 'axios';
+import { rootReducer } from './redux/reducer';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-
-const user = {id:null, name:null, profileImage:null, accountEmail:null, aToken:null};
-//const user = {id:-1, name:"이유진", profileImage:"/img/logo.png", accountEmail:"y@d.n"};
 
 const persistConfig = {
   key : root,
   storage: storageSession,
 }
 
-const persistedReducer = persistReducer(persistConfig, myReducer);
-
-function myReducer(state = user, action){
-    if(action.type === '로그인'){
-      return {id:action.user.id, name:action.user.name, accountEmail:action.user.accountEmail, profileImage:action.user.profileImage, aToken:action.user.aToken};
-    }
-    else if(action.type === '로그아웃')
-      window.sessionStorage.clear();
-    
-    else if(action.type === '별명수정'){
-      axios.put("/member/name", {
-        headers: {
-          Authorization: `Bearer ${state.aToken}`
-        },
-        params: {
-          name: `${action.user.name}`
-        }
-      });
-
-      return {...state, name:action.user.name};
-    }
-
-    else
-      return state;
-  }
-
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 const store = configureStore({reducer : persistedReducer}, applyMiddleware());
 const Persistor = persistStore(store);
 

--- a/src/redux/memberReducer.js
+++ b/src/redux/memberReducer.js
@@ -1,0 +1,27 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const memberInitialState = {
+    accountEmail: "",
+    id: 0,
+    name: "",
+    profileImage: "",
+    signed: false
+};
+
+const memberSlice = createSlice({
+    name: "member",
+    initialState: memberInitialState,
+    reducers: {
+        setMember(state, action) {
+            state.id = action.payload.id;
+            state.name = action.payload.name;
+            state.accountEmail = action.payload.accountEmail;
+            state.profileImage = action.payload.profileImage;
+            state.signed = true;
+        },
+        clearMember: () => memberInitialState
+    },
+});
+
+export const { setMember, clearMember } = memberSlice.actions;
+export const memberReducer = memberSlice.reducer;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -1,0 +1,15 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { combineReducers } from "redux";
+import { tokenReducer } from "./tokenReducer";
+import { memberReducer } from "./memberReducer";
+
+const rootReducer = combineReducers({
+    token: tokenReducer,
+    member: memberReducer
+});
+
+const Store = configureStore({
+    reducer: rootReducer,
+});
+
+export { Store, rootReducer };

--- a/src/redux/tokenReducer.js
+++ b/src/redux/tokenReducer.js
@@ -1,0 +1,21 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const tokenInitialState = {
+    accessToken: "",
+    refreshToken: "",
+};
+
+const tokenSlice = createSlice({
+    name: "token",
+    initialState: tokenInitialState,
+    reducers: {
+        login(state, action) {
+            state.accessToken = action.payload.accessToken;
+            state.refreshToken = action.payload.refreshToken;
+        },
+        logout: () => tokenInitialState
+    },
+});
+
+export const { login, logout } = tokenSlice.actions;
+export const tokenReducer = tokenSlice.reducer;

--- a/src/routes/Join.js
+++ b/src/routes/Join.js
@@ -2,10 +2,12 @@ import React, { useEffect } from "react";
 import Navigation from "../components/Navigation";
 import { useSelector, useDispatch } from 'react-redux';
 import './Join.css';
+import { useParams } from "react-router-dom";
 
 function Join() {
-    const user = useSelector( (state) => state );
+    const member = useSelector(state => state.member);
     const dispatch = useDispatch();
+    const { initialName } = useParams();
 
     var spc = /[.,~!@#$%^&*()_+|<>?:{}]/;
     var blank = /[\s]/g;
@@ -44,18 +46,18 @@ function Join() {
     }
 
     useEffect(() => {
-        console.log(user.name + " / " + user.accountEmail + " / " + user.profileImage)
-    }, []);
+        console.log(member.name + " / " + member.accountEmail + " / " + member.profileImage)
+    }, [member]);
 
     const submitNick = () => {
         let newNick = document.getElementById("input").value;
         
         if(newNick.length === 0)
-            newNick = `${user.name}`;
+            newNick = `${member.name}`;
         
         dispatch({ 
             type:'별명수정',
-            user : {id:user.id, name:newNick, accountEmail:user.accountEmail, profileImage:user.profileImage, aToken:user.aToken}
+            user : {id:member.id, name:newNick, accountEmail:member.accountEmail, profileImage:member.profileImage}
         });
 
         window.location.href = "/home";
@@ -71,7 +73,7 @@ function Join() {
             <div className="nicknameGuide">‘Missul;GAN’에서 사용할 별명을 적어주세요.</div>
 
             <div id="nicknameBox">
-                <input id="input" onChange={onChange} type="text" minLength={2} maxLength={12} placeholder={user.name}/>
+                <input id="input" onChange={onChange} type="text" minLength={2} maxLength={12} placeholder={initialName}/>
                 <button id="submitButton" onClick={submitNick}> 별명 설정 완료 </button>
             </div>
 

--- a/src/routes/Login.js
+++ b/src/routes/Login.js
@@ -1,37 +1,38 @@
 import axios from "axios";
 import { useEffect } from "react";
-import { useNavigate } from 'react-router-dom';  
+import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { login } from "../redux/tokenReducer";
+import { setMember } from "../redux/memberReducer";
 
 function Login() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
 
-    const dispatch = useDispatch();
-    let navigate = useNavigate();
+  const accessToken = new URL(window.location.href).searchParams.get("accessToken");
+  const refreshToken = new URL(window.location.href).searchParams.get("refreshToken");
+  const name = new URL(window.location.href).searchParams.get("name");
+  const isFirstTime = new URL(window.location.href).searchParams.get("firstTime");
 
-    let aToken = new URL(window.location.href).searchParams.get("accessToken");
-    let rToken = new URL(window.location.href).searchParams.get("refreshToken");
-    let name = new URL(window.location.href).searchParams.get("name");
-    let isFirstTime = new URL(window.location.href).searchParams.get("firstTime");
-
-    useEffect(() => {
-        axios.get("/member/me", {
-          headers: {
-            Authorization: `Bearer ${aToken}`,
-          },
-        })
-        .then(function (res) {
-          dispatch({ 
-            type : '로그인',
-            user : {id:res.data.id, name:res.data.name, accountEmail:res.data.accountEmail, profileImage:res.data.profileImage, aToken:aToken}
-          });
-
-          if(true) //isFirstTime 들어갈 자리
-            navigate('/join'); 
-
-          else 
-            navigate('/home'); 
-        });
-    }, []);
+  useEffect(() => {
+    const loginDispatch = (token, member) => {
+      dispatch(login(token));
+      dispatch(setMember(member));
+    };
+    axios.get("https://api.missulgan.art/member/me", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+      .then(res => {
+        const { data: member } = res;
+        loginDispatch({ accessToken, refreshToken }, member);
+        if (isFirstTime === true) //isFirstTime 들어갈 자리
+          navigate(`/join/${name}`);
+        else
+          navigate('/home');
+      });
+  }, [name, isFirstTime, accessToken, refreshToken, navigate, dispatch]);
 }
 
 export default Login;


### PR DESCRIPTION
# 변경 사항
- **로그인**을 하고
- **토큰**을 받아오고 **저장**
- **사용자 정보**를 받아오고
- **사용자 정보**를 **저장**하는

부분을 다듬었습니다.
- 그리고 **Proxy Middleware** 가 필요하지 않도록 서버(BE)를 설정했어요

어플리케이션의 기반이 되는 부분이기에 충돌이 있더라도 양해부탁드려요 🥲
=> 충돌 해결 완료

# 설명

## 현재 저장된 redux `state` 확인하기

1. [`redux devtools`](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) 크롬 확장 프로그램 설치
2. 웹 어플리케이션 열기(`localhost:3000`)
3. 설치한 확장 프로그램 열기
- **고정** 해놓으면 바로 열기 가능
- 아이콘 우클릭 시 새창으로 열기 가능
  <img width="687" alt="image" src="https://user-images.githubusercontent.com/39221443/184856411-a390f892-f778-4892-b27b-0b437dcf002f.png">

5. 활용

  | 트리로 보기 | JSON으로 보기 |
  |------|-------|
  |  ![](https://user-images.githubusercontent.com/39221443/184855266-b6f406bb-2114-458c-b382-071720c719e6.png)  | ![](https://user-images.githubusercontent.com/39221443/184855629-2149d083-93c6-4f58-9159-f491827c9d25.png)    | 

  | 차트로 보기 |
  |-------|
  |   ![](https://user-images.githubusercontent.com/39221443/184855473-de13af23-28dc-487b-a7f2-1bace8db7ce6.png)    |

## 로그인 후 저장되었던 유저 정보 가져오기
(import 필요!!)
```javascript
const member = useSelector(state => state.member)
```
상단 선언 후
```javascript
console.log(member.accountEmail); // email@example.com
console.log(member.signed); // true
```
이런 식으로 사용 가능