### PR TITLE
refactor: redux state 구조 변경에 따른 변수명 변경 (Drawing.js / UserDrawing.js)

### DIFF
--- a/src/routes/Drawing.js
+++ b/src/routes/Drawing.js
@@ -5,7 +5,8 @@ import './Drawing.css';
 
 function Drawing({ind, drawing}){
 
-    const user = useSelector( (state) => state );
+    const member = useSelector(state => state.member);
+    const accessToken = useSelector(state => state.token.accessToken);
     const [like, setLike] = useState(false);
     const [bookmark, setBookmark] = useState(false);
     const [seeNFT, setSeeNFT] = useState(true);
@@ -25,8 +26,8 @@ function Drawing({ind, drawing}){
     }
 
     function clickLike() {
-        if(user.name !== null){
-            if(user.id === drawing.member.id)
+        if(member.signed){
+            if(member.id === drawing.member.id)
                 alert("본인이 만든 작품에는 좋아요를 누를 수 없습니다.");
             
             else {
@@ -37,7 +38,7 @@ function Drawing({ind, drawing}){
     
                     axios.post(`/heart/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -46,7 +47,7 @@ function Drawing({ind, drawing}){
                     
                     axios.delete(`/heart/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -60,8 +61,8 @@ function Drawing({ind, drawing}){
     }
 
     function clickBookmark() {
-        if (user.name !== null){
-            if(user.id === drawing.member.id)
+        if (member.signed){
+            if(member.id === drawing.member.id)
                 alert("본인이 만든 작품은 스크랩할 수 없습니다.");
 
             else {
@@ -72,7 +73,7 @@ function Drawing({ind, drawing}){
     
                     axios.post(`/scrap/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -81,7 +82,7 @@ function Drawing({ind, drawing}){
     
                     axios.delete(`/scrap/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }

--- a/src/routes/UserDrawing.js
+++ b/src/routes/UserDrawing.js
@@ -4,7 +4,9 @@ import { useSelector } from 'react-redux';
 import './UserDrawing.css';
 
 function UserDrawing({ ind, drawing, mine, clickDelete }) {
-    const user = useSelector(state => state);
+
+    const member = useSelector(state => state.member);
+    const accessToken = useSelector(state => state.token.accessToken);
     const [like, setLike] = useState(false); // 서버에서 받은 정보로 초기값 넣기
     const [bookmark, setBookmark] = useState(false); // 서버에서 받은 정보로 초기값 넣기
     const [seeNFT, setSeeNFT] = useState(true);
@@ -24,8 +26,8 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
     }
 
     function clickLike() {
-        if(user.name !== null){
-            if(user.id === drawing.member.id)
+        if(member.signed){
+            if(member.id === drawing.member.id)
                 alert("본인이 만든 작품에는 좋아요를 누를 수 없습니다.");
             
             else {
@@ -36,7 +38,7 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
     
                     axios.post(`/heart/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -45,7 +47,7 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
                     
                     axios.delete(`/heart/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -59,8 +61,8 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
     }
 
     function clickBookmark() {
-        if (user.name !== null){
-            if(user.id === drawing.member.id)
+        if (member.signed){
+            if(member.id === drawing.member.id)
                 alert("본인이 만든 작품은 스크랩할 수 없습니다.");
 
             else {
@@ -71,7 +73,7 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
     
                     axios.post(`/scrap/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }
@@ -80,7 +82,7 @@ function UserDrawing({ ind, drawing, mine, clickDelete }) {
     
                     axios.delete(`/scrap/${drawing.id}`, {
                         headers: {
-                          Authorization: `Bearer ${user.aToken}`,
+                          Authorization: `Bearer ${accessToken}`,
                         }
                     });
                 }


### PR DESCRIPTION
* Drawing.js, UserDrawing.js

  * 변수명 변경: user -> member
  * 굳이 state.member랑 state.token으로 나눠서 불러온 이유<br/><br/>

  ```javascript
  //방식 1 - member, token을 따로따로 불러옴 (지금 커밋한 방식)
  const member = useSelector(state => state.member);
  const accessToken = useSelector(state => state.token.accessToken);

  //방식 2 - state를 전부 들고와서(?) 사용자 정보는 state.member.xx / 토큰은 state.token.xx 으로 사용
  const member = useSelector(state => state);
  ```

  두번째 방법으로 하면 사용자 정보/토큰 쓸 때 member.member.signed 나 member.token.accessToken으로 쓰게 되는데<br/> 이름이 너무 길고 전자 같은 경우는 member가 두 번 나오는게 왠지 별로인 거 같아서...................