### PR TITLE
fix: 태그 선택 해제시 backgroundColor 색상코드 변경

### DIFF
--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -248,10 +248,10 @@ function Home() {
 
         if(document.getElementById(e.target.className).checked){
             document.getElementsByClassName(e.target.className)[0].style.backgroundColor = "#3C6B50";
-            document.getElementsByClassName(e.target.className)[0].style.color = "#FFFFFF";
+            document.getElementsByClassName(e.target.className)[0].style.color = "#F4F4F4";
         }
         else {  
-            document.getElementsByClassName(e.target.className)[0].style.backgroundColor = "#FFFFFF";
+            document.getElementsByClassName(e.target.className)[0].style.backgroundColor = "#F4F4F4";
             document.getElementsByClassName(e.target.className)[0].style.color = "#3C6B50";
         }
 


### PR DESCRIPTION
## 변경 사항

* Home.js 의 checkTag() (체크해제시 배경 컬러가 #FFFFFF - 쌩 흰색으로 들어가있어서 사라지던거였네요 ^^,,)

  ![image](https://user-images.githubusercontent.com/87255462/185176709-3e04e120-8cec-4c2b-9692-ab163dc696ee.png)
