### PR TITLE
MyPage.js array.slice 기준 index 변경

### DIFF
--- a/src/routes/MyPage.js
+++ b/src/routes/MyPage.js
@@ -80,11 +80,11 @@ function MyPage() {
                             <div id="drawingBox1">
                                 {option === "my"
                                     ?
-                                    mydrawing.slice(0, 4).map((element) =>
+                                    mydrawing.slice(0, parseInt(mydrawing.length/3)).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} mine={true} clickDelete={clickDelete} clickScrap={clickScrap} openDetailModal={openDetailModal} />
                                     )
                                     :
-                                    myscrap.slice(0, 4).map((element) =>
+                                    myscrap.slice(0, parseInt(myscrap.length/3)).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} clickDelete={clickDelete} clickScrap={clickScrap} clickUnScrap={clickUnscrap} openDetailModal={openDetailModal} />
                                     )
                                 }
@@ -93,11 +93,11 @@ function MyPage() {
                             <div id="drawingBox2">
                                 {option === "my"
                                     ?
-                                    mydrawing.slice(4, 6).map((element) =>
+                                    mydrawing.slice(parseInt(mydrawing.length/3), 2 * parseInt(mydrawing.length/3)).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} mine={true} clickDelete={clickDelete} clickScrap={clickScrap} openDetailModal={openDetailModal} />
                                     )
                                     :
-                                    myscrap.slice(4, 6).map((element) =>
+                                    myscrap.slice(parseInt(myscrap.length/3), 2 * parseInt(myscrap.length/3)).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} clickDelete={clickDelete} clickScrap={clickScrap} clickUnScrap={clickUnscrap} openDetailModal={openDetailModal} />
                                     )
                                 }
@@ -106,11 +106,11 @@ function MyPage() {
                             <div id="drawingBox3">
                                 {option === "my"
                                     ?
-                                    mydrawing.slice(6,).map((element) =>
+                                    mydrawing.slice(2 * parseInt(mydrawing.length/3),).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} mine={true} clickDelete={clickDelete} clickScrap={clickScrap} openDetailModal={openDetailModal} />
                                     )
                                     :
-                                    myscrap.slice(6,).map((element) =>
+                                    myscrap.slice(2 * parseInt(myscrap.length/3),).map((element) =>
                                         <UserDrawing key={element.id} drawing={element} clickScrap={clickScrap} clickUnScrap={clickUnscrap} openDetailModal={openDetailModal} />
                                     )
                                 }


### PR DESCRIPTION
## 변경사항

### MyPage.js
'내 작품' 과 '스크랩한 작품' 배열에 array.slice() 함수를 사용, 3줄로 나눠서 보여주는 코드가 있습니다
각 줄의 가로 크기가 달라서 이 개수를 어떻게 잘 분배를 할까.,,,, 고민을 계속 했었는데요 그냥 공평하게 3으로 나눠서 넣어줬습니다

(1) 각 줄의 비율을 고려해서 서로 다른 개수를 넣어준다
➡ 사실 비율을 따지면 (2x : x : x+1) 로 들어가는게 제일 좋은데요 문제는 그림의 세로 길이가 다 달라서 의미가 없읍니다

(2) 그림마다 세로 길이를 따져서 잘 넣어준다
➡ 기절

#### 결론
slice()의 기준은 __배열 길이를 3으로 나눈 몫__ 이 되었습니다 (parseInt(length / 3)
```javascript
mydrawing.slice(0, parseInt(mydrawing.length/3)) // 왼쪽
mydrawing.slice(parseInt(mydrawing.length/3), 2 * parseInt(mydrawing.length/3)) // 가운데
mydrawing.slice(2 * parseInt(mydrawing.length/3), ) // 오른쪽
```
예) 그림 9개 -> 3 3 3 / 그림 13개 -> 4 4 5

#### 문제 겸 논의할 부분 - 만약 그림이 3개 미만이라면?
그림이 1, 2개인 경우 몫이 0이라서 위 코드에 대입하면 0 0 1 / 0 0 2 로 들어갑니다
![image](https://user-images.githubusercontent.com/87255462/185793025-14cad021-5656-4dec-9750-57dbe36fade3.png)

구린거 같아요........................... 그래서 제 생각은 오른쪽 줄과 왼쪽 줄의 순서를 바꾸면 어떨까 싶어요

```javascript
mydrawing.slice(2 * parseInt(mydrawing.length/3), ) // 왼쪽
mydrawing.slice(parseInt(mydrawing.length/3), 2 * parseInt(mydrawing.length/3)) // 가운데
mydrawing.slice(0, parseInt(mydrawing.length/3)) // 오른쪽
```

보통 왼쪽부터 읽잖아요 ~~저만 그런거면 송죄합니다~~ 저렇게 하면 위와 같은 상황에서도 왼쪽 줄에만 담기니까 괜찮을 것 같고,<br/>배열의 뒤쪽부터 보여주니까 최근에 만든 그림일수록 먼저 등장해서 나쁘지 않을 것 같다는 생각입니다
~~사실 뒤쪽 덩어리를 숭덩. 잘라서 보여주는거지 배열 자체를 거꾸로 보여주는게 아니라 100% 최신순이라고 하긴 좀 그렇지만요~~



