### PR TITLE
feat: DetailModal 내 NFT 버튼 활성/비활성화

### DIFF
--- a/src/routes/DetailModal.css
+++ b/src/routes/DetailModal.css
@@ -93,6 +93,19 @@
     width: 95%;
 }
 
+#modal .buttonBox #open-nft-button {
+    background-color: #3C6B50;
+    border-radius: 8px;
+    font-weight: 200;
+    color: white;
+    width: 270px;
+    height: 60px;
+    
+    margin-top: 12px;
+    margin-right: 30px;
+    margin-left: 10px;
+}
+
 #modal .likeBox, .bookmarkBox {
     height: fit-content;
     margin-top: 10px;

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { heart, unheart } from "../api/heartApi";
 import { scrap, unscrap } from "../api/scrapApi";
 import { useSelector } from "react-redux";
@@ -10,7 +10,9 @@ function DetailModal({ drawing, home, clickDelete, handleDetailModalClose, openL
 
     const [like, setLike] = useState(false);
     const [bookmark, setBookmark] = useState(false);
+
     const [seeNFT, setSeeNFT] = useState(true);
+    const nftRef = useRef();
 
     const img = "https://api.missulgan.art/image/"+drawing.fileName;
 
@@ -71,9 +73,7 @@ function DetailModal({ drawing, home, clickDelete, handleDetailModalClose, openL
 
     function clickNFT() {
         setSeeNFT(!seeNFT);
-        const NFTInfo = document.getElementsByClassName("NFTBox")[0];
-        let see = seeNFT ? "inline" : "none";
-        NFTInfo.style.display = see;
+        nftRef.current.style.display = seeNFT ? "inline" : "none";
     }
     
     function requestDelete() {
@@ -111,22 +111,16 @@ function DetailModal({ drawing, home, clickDelete, handleDetailModalClose, openL
                                 <button style={{ border: "none", backgroundColor: "rgb(0,0,0,0)" }}> <a href="/img/logo.png" download> <img src="/img/downloadIcon.png" width="60px" alt="" /> </a> </button>
                                 <KakaoDrawingShareButton drawing={drawing}></KakaoDrawingShareButton>
 
-
                                 { !home && drawing.member.id === member.id &&
                                     <>
                                         <button> <img src="/img/openseaIcon.png" width="60px" alt="" /> </button>
                                         <button onClick={requestDelete}> <img src="/img/binIcon.png" width="60px" alt="" /> </button>
                                     </>
-
                                 }
 
-                                <button style={{
-                                    backgroundColor: "#3C6B50",
-                                    border: "none", borderRadius: "8px",
-                                    fontWeight: "200", color: "white",
-                                    width: "270px", height: "60px",
-                                    marginTop: "8px", marginRight: "30px", marginLeft: "5px"
-                                }} onClick={clickNFT}> OpenSea 통계 정보 </button>
+                                <button id="open-nft-button" onClick={clickNFT} style={!drawing.nft && {opacity: "0.5", cursor: "not-allowed"}} disabled={!drawing.nft && true}> 
+                                    NFT 통계 정보 
+                                </button>
 
                                 <div className="likeBox">
                                     <button className="like" onClick={clickLike}> <img src={like ? "/img/Like.png" : "/img/emptyLike.png"} width={32} alt="" /> </button>
@@ -139,7 +133,7 @@ function DetailModal({ drawing, home, clickDelete, handleDetailModalClose, openL
                                 </div>
                             </div>
 
-                            <div className="NFTBox">
+                            <div className="NFTBox" ref={nftRef}>
                                 어쩌고저쩌고<br />
                                 이 작품의 NFT 가격!! 247239857198321093원<br />
                                 아무튼 통계 정보~~~ 들어갈 자리~~~


### PR DESCRIPTION
## 변경사항

### DetailModal.js
* 단어 수정 : OpenSea 통계 정보 ➡ NFT 통계 정보
* CSS가 안 먹혀서 style 태그에 걸어놨던거 DetailModal.css로 이동
* drawing.nft 값에 따라 버튼 이용 가능 여부 조절

  * NFT 버튼 눌러서 정보 열 때 useRef 사용 <br/><br/>

발행되지 않은 작품 (+ 마우스 커서 🚫)
![image](https://user-images.githubusercontent.com/87255462/185801216-17b2f990-74a9-4929-8abc-90dcc6d2f3e5.png)

발행된 작품 (눌러서 열었을 때)
![image](https://user-images.githubusercontent.com/87255462/185801274-5a3fc59b-02fd-4633-803d-9200db351ad6.png)

