### PR TITLE
fix: DetailModal 열렸을 때 바닥 스크롤 제어

### DIFF
--- a/src/routes/DetailModal.css
+++ b/src/routes/DetailModal.css
@@ -1,7 +1,7 @@
 #modal.drawing-modal {
-    width: 100vw;
-    height: 100vh;
-    position: absolute;
+    width: 100%;
+    height: 100%;
+    position: fixed;
     left: 0;
     top: 0;
     display: flex;

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -28,7 +28,6 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
 
     function clickClose() {
         handleDetailModalClose();
-        document.body.style.overflow = "visible";
     }
 
     function clickLike() {
@@ -110,10 +109,9 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         }
     }
 
-
     useEffect(() => {
-        document.body.style.overflow = "hidden";
         modalRef.current.style.top = `${window.scrollY}px`;
+        modalRef.current.style.position = "fixed";
     }, []);
 
     return (

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -20,8 +20,6 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
     const [seeNFT, setSeeNFT] = useState(true);
     const nftRef = useRef();
 
-    const modalRef = useRef();
-
     const img = "https://ipfs.io/ipfs/"+drawing.fileName;
 
     const navigate = useNavigate();
@@ -109,13 +107,8 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         }
     }
 
-    useEffect(() => {
-        modalRef.current.style.top = `${window.scrollY}px`;
-        modalRef.current.style.position = "fixed";
-    }, []);
-
     return (
-        <div id="modal" className="drawing-modal" ref={modalRef}>
+        <div id="modal" className="drawing-modal">
             <Grow in={drawing}>
                 <div className="drawing-modal-window">
                     <div className="drawing-modal-left"> <img className="large-drawing" src={img} alt="" /> </div>

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { heart, unheart } from "../api/heartApi";
 import { scrap, unscrap } from "../api/scrapApi";
 import { useSelector } from "react-redux";
@@ -20,12 +20,15 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
     const [seeNFT, setSeeNFT] = useState(true);
     const nftRef = useRef();
 
+    const modalRef = useRef();
+
     const img = "https://ipfs.io/ipfs/"+drawing.fileName;
 
     const navigate = useNavigate();
 
     function clickClose() {
         handleDetailModalClose();
+        document.body.style.overflow = "visible";
     }
 
     function clickLike() {
@@ -38,7 +41,6 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
 
                 if (!like) {
                     drawing.heartCount++;
-
                     heart(drawing.id);
                 }
                 else {
@@ -108,8 +110,14 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         }
     }
 
+
+    useEffect(() => {
+        document.body.style.overflow = "hidden";
+        modalRef.current.style.top = `${window.scrollY}px`;
+    }, []);
+
     return (
-        <div id="modal" className="drawing-modal">
+        <div id="modal" className="drawing-modal" ref={modalRef}>
             <Grow in={drawing}>
                 <div className="drawing-modal-window">
                     <div className="drawing-modal-left"> <img className="large-drawing" src={img} alt="" /> </div>
@@ -120,7 +128,7 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                             <div>
                                 <div className="userInfo">
                                     <img src={drawing.member.profileImage} alt="" className="profileImg" width={50} height={50} />
-                                    <p className="author" onClick={() => { navigate(`/userPage/${drawing.member.id}`) }}>
+                                    <p className="author" onClick={() => { navigate(`/userPage/${drawing.member.id}`); document.body.style.overflow = "visible"; }}>
                                         {drawing.member.name}
                                     </p>
                                 </div>


### PR DESCRIPTION
## 변경사항

### DetailModal.js

* 모달이 현재 스크롤 위치에 열리게 했습니다 (원래 최상단에 열리는 슬픈 ㅣ일이 일어나고 있었어요)
* 모달이 열린 상태에서는 배경 세로 스크롤 움직이지 못하게 아예 숨겨버렸습니다 (닫으면 다시 나타나요)

![가로가로](https://user-images.githubusercontent.com/87255462/185981957-eebf1dae-30ea-495c-90a5-6f8e480fa71c.gif)

