### PR TITLE
feat: 좋아요/스크랩 목록 

### DIFF
--- a/src/api/scrapApi.js
+++ b/src/api/scrapApi.js
@@ -1,5 +1,10 @@
 import { Axios } from "./api";
 
+export const getScrapMembers = async (drawingId) => {
+    const response = await Axios.get(`/scrap/${drawingId}`);
+    return response.data;
+}
+
 export const getScrap = async () => {
     const response = await Axios.get(`/scrap`);
     return response.data;

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -1,6 +1,6 @@
-import React, { useState, useRef } from "react";
-import { heart, unheart } from "../api/heartApi";
-import { scrap, unscrap } from "../api/scrapApi";
+import React, { useState, useRef, useEffect } from "react";
+import { getHeartMembers, heart, unheart } from "../api/heartApi";
+import { getScrapMembers, scrap, unscrap } from "../api/scrapApi";
 import { editDrawing } from "../api/drawingApi";
 import { useSelector } from "react-redux";
 import { useNavigate } from 'react-router';
@@ -9,6 +9,7 @@ import KakaoDrawingShareButton from '../components/KakaoDrawingShareButton';
 import { Grow } from "@mui/material";
 import { useOutletContext } from "react-router-dom";
 import EditTags from "../components/EditTags";
+import ReactionList from "./ReactionList";
 
 function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
     const member = useSelector(state => state.member);
@@ -24,22 +25,13 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
     }
 
     const IMG = "https://ipfs.io/ipfs/" + drawing.fileName;
-    
+
+    const [showLikeList, setShowLikeList] = useState(false);
+    const handleshowLikeListOpen = () => { setShowLikeList(true); }
+    const handleshowLikeListClose = () => { setShowLikeList(false); }
+
     const [like, setLike] = useState(false);
-    const [bookmark, setBookmark] = useState(false);
-    const [seeNFT, setSeeNFT] = useState(true);
-
-    const nftRef = useRef();
-    const modalExternalRef = useRef();
-    const closeButtonRef = useRef();
-
-    const clickClose = (e) => { 
-        if(modalExternalRef.current === e.target || closeButtonRef.current === e.target) {
-            e.stopPropagation();
-            handleDetailModalClose();
-        }
-    } 
-
+    const [likeList, setLikeList] = useState([]);
     const clickLike = () => {
         if (member.signed) {
             if (member.id === drawing.member.id)
@@ -51,16 +43,25 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                 if (!like) {
                     drawing.heartCount++;
                     heart(drawing.id);
+                    setLikeList([member, ...likeList]);
                 }
                 else {
                     drawing.heartCount--;
                     unheart(drawing.id);
+                    setLikeList(likeList.filter(m => m.id !== member.id)); // 근데 이건 첫 요소만 제외한 새 배열이 필요한거라 굳이 필터를 쓸 이유가
                 }
             }
         }
         else
             openLoginAlert();
     }
+
+    const [showScrapList, setShowScrapList] = useState(false);
+    const handleshowScrapListOpen = () => { setShowScrapList(true); }
+    const handleshowScrapListClose = () => { setShowScrapList(false); }
+
+    const [bookmark, setBookmark] = useState(false);
+    const [bookmarkList, setBookmarkList] = useState([]);
     const clickBookmark = () => {
         if (member.signed) {
             if (member.id === drawing.member.id)
@@ -72,12 +73,15 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                 if (!bookmark) {
                     drawing.scrapCount++;
                     scrap(drawing.id);
+                    setBookmarkList([member, ...bookmarkList]);
                 }
                 else {
                     drawing.scrapCount--;
 
-                    if (home)
+                    if (home){
                         unscrap(drawing.id);
+                        setBookmarkList(bookmarkList.filter(m => m.id !== member.id));
+                    }
                     else {
                         handleDetailModalClose();
                         clickDelete(drawing.id);
@@ -89,6 +93,17 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
             openLoginAlert();
     }
 
+    const modalExternalRef = useRef();
+    const closeButtonRef = useRef();
+    const clickClose = (e) => {
+        if (modalExternalRef.current === e.target || closeButtonRef.current === e.target) {
+            e.stopPropagation();
+            handleDetailModalClose();
+        }
+    }
+
+    const [seeNFT, setSeeNFT] = useState(true);
+    const nftRef = useRef();
     const clickNFT = () => {
         setSeeNFT(!seeNFT);
         nftRef.current.style.display = seeNFT ? "inline" : "none";
@@ -113,7 +128,6 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         }
     }
 
-
     const TAGS = [
         { name: "어두운", tagId: 1 },
         { name: "화사한", tagId: 2 },
@@ -134,13 +148,9 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         { name: "우키요에", tagId: 11 },
     ]
 
-    const [edit, setEdit] = useState(true);
-    const clickEdit = () => { setEdit(!edit); }
-
     const [newTagIds, setNewTagIds] = useState(drawing.tags.map((t) => { return t.id }));
     const newTitleRef = useRef();
     const newDescriptionRef = useRef();
-
     const tagChanged = (e) => {
         const tagId = e.target.value;
 
@@ -166,6 +176,8 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         }
     }
 
+    const [edit, setEdit] = useState(true);
+    const clickEdit = () => { setEdit(!edit); }
     const finishEditing = () => {
         setEdit(!edit);
 
@@ -184,6 +196,14 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
             ...STYLE_TAGS.filter(tag => newTagIds.indexOf(tag.tagId) !== -1)
         ];
     }
+
+    useEffect(() => {
+        async function getDrawingReactions() {
+            setLikeList(await getHeartMembers(drawing.id));
+            setBookmarkList(await getScrapMembers(drawing.id));
+        }
+        getDrawingReactions();
+    }, []);
 
     return (
         <div id="modal" className="drawing-modal" onClick={clickClose} ref={modalExternalRef}>
@@ -236,7 +256,7 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                                                         </label>
                                                     )
                                             })}
-                                            
+
                                             <EditTags tags={TAGS} newTags={newTagIds} tagChanged={tagChanged} />
                                         </div>
                                     </>
@@ -260,12 +280,12 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
 
                                         <div className="likeBox">
                                             <button className="like" onClick={clickLike}> <img src={like ? "/img/Like.png" : "/img/emptyLike.png"} width={32} alt="" /> </button>
-                                            <p> {drawing.heartCount} </p>
+                                            <p id="heartCount" onClick={handleshowLikeListOpen}> {drawing.heartCount} </p>
                                         </div>
 
                                         <div className="bookmarkBox">
                                             <button className="bookmark" onClick={clickBookmark}> <img src={bookmark ? "/img/bookmark.png" : "/img/emptyBookmark.png"} width={28} alt="" /> </button>
-                                            <p> {drawing.scrapCount} </p>
+                                            <p id="scrapCount" onClick={handleshowScrapListOpen}> {drawing.scrapCount} </p>
                                         </div>
                                     </>
                                     :
@@ -274,7 +294,6 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                                         <button id="edit-complete" onClick={finishEditing}> 수정 완료 </button>
                                     </div>
                                 }
-
                             </div>
 
                             <div className="NFTBox" ref={nftRef}>
@@ -286,6 +305,14 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
                     </div>
                 </div>
             </Grow>
+
+            {showLikeList &&
+                <ReactionList count={drawing.heartCount} list={likeList} close={handleshowLikeListClose} like={true}/>
+            }
+            
+            {showScrapList &&
+                <ReactionList count={drawing.scrapCount} list={bookmarkList} close={handleshowScrapListClose} like={false}/>
+            }
         </div>
     );
 }

--- a/src/routes/ReactionList.css
+++ b/src/routes/ReactionList.css
@@ -1,0 +1,75 @@
+#listModal-background {
+    width: 100%;
+    height: 100%;
+
+    background-color: rgb(0, 0, 0, 0.2);
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+#listModal {
+    background-color: white;
+    border-radius: 10px;
+    padding: 20px;
+    width: 350px;
+    height: 400px;
+    overflow: auto;
+}
+
+#listModal::-webkit-scrollbar {
+    background-color: white;
+    height: 15px;
+    border-radius: 10px;
+}
+
+#listModal::-webkit-scrollbar-thumb {
+    background-color: #9F9F9F;
+    border-radius: 20px;
+    background-clip: padding-box;
+    border: 5px solid transparent;
+}
+
+#listModal::-webkit-scrollbar-track {
+    background-color: white;
+    border-radius: 20px;
+}
+
+#info-box {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    position: relative;
+    font-size: 1rem;
+}
+
+#list-modal-close {
+    position: absolute;
+    right: 0;
+}
+
+#user-info {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5%;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #F4F4F4;
+}
+
+#user-info img {
+    width: 60px;
+    height: 60px;
+    border-radius: 25px;
+}
+
+#user-info div {
+    font-weight: 400;
+    font-size: 20px;
+    margin-left: 3%;
+    cursor: pointer;
+}

--- a/src/routes/ReactionList.js
+++ b/src/routes/ReactionList.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import './ReactionList.css';
+
+function ReactionList({ count, list, close, like }) {
+    const textRef = useRef();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if(like)
+            textRef.current.innerHTML = `${count}명이 이 작품을 좋아합니다.`;
+        else
+            textRef.current.innerHTML = `${count}명이 이 작품을 스크랩합니다.`
+    }, []);
+
+    return (
+        <div id="listModal-background">
+            <div id="listModal">
+                <div id="info-box">
+                    <div ref={textRef} />
+                    <img id="list-modal-close" src="/img/closeButton.png" width="25" alt="" onClick={close} />
+                </div>
+                <hr />
+
+                {list.map(i =>
+                    <>
+                        <div id="user-info">
+                            <img src={i.profileImage} alt="" />
+                            <div onClick={() => {navigate(`/userPage/${i.id}`);}}> {i.name} </div>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default ReactionList;


### PR DESCRIPTION
## 변경사항

* 숫자 누르면 모달로 좋아요/스크랩 리스트가 보입니다
* 특정 유저의 이름 클릭 시 유저 페이지로 이동합니다 (이 상태에서 뒤로오면 다시 상세보기 모달)

![가로가로](https://user-images.githubusercontent.com/87255462/187061021-06b0f1af-920e-434c-828f-2a6919560490.gif)

### 반성문 ^^....
지금 DetailModal.js가 320줄짜리 거대한,,, 무언가가 되었는데 nft 정보 보여주는 것까지 하면 진짜 400줄 찍을 거 같아요,,,,,,,,,,,,,,,,<br/> 위치를 좀 관련 있는 변수+함수끼리 묶어둔다고 묶어두긴 했는데 그래도 읽기 힘드실 거 같아요 반성하겠읍니다 이거 PR 올려놓고 NFT 정보 보는 것까지 하고 리팩토링,,,, 하겠스빈다,,,,

(아래 커밋이 12개나 되는데 이게 develop 에서 뻗어나온 브랜치가 아니라 detailmodal 에서 뻗어나온 브랜치라 거기 커밋까지 같이 찍혔어요 실제로 여기랑 관련있는 커밋은 제일 마지막 커밋입니닥)