### PR TITLE
fix: 태그 추가 및 id 수정

### DIFF
--- a/src/routes/CreateDrawing.js
+++ b/src/routes/CreateDrawing.js
@@ -34,7 +34,7 @@ function CreateDrawing() {
     const dispatchPresetTagId = (presetTagId) => dispatch(savePresetTagId(presetTagId));
     const setPresetTagId = (preset) => {
         if (preset === "cnn")
-            dispatchPresetTagId(null);
+            dispatchPresetTagId(12);
         else
             dispatchPresetTagId(preset);
     };

--- a/src/routes/SaveDrawing.js
+++ b/src/routes/SaveDrawing.js
@@ -14,6 +14,7 @@ const STYLES = [
     { name: "클로드 모네", tagId: 9 },
     { name: "폴 세잔", tagId: 10 },
     { name: "우키요에", tagId: 11 },
+    { name: "DIY", tagId: 12}
 ];
 
 const TAGS = [
@@ -24,10 +25,9 @@ const TAGS = [
     { name: "강렬한", tagId: 5 },
     { name: "차가운", tagId: 6 },
     { name: "따뜻한", tagId: 7 },
-    { name: "풍경", tagId: 12 },
-    { name: "동물", tagId: 13 },
-    { name: "인물", tagId: 14 },
-    { name: "기타", tagId: 15 },
+    { name: "풍경", tagId: 13 },
+    { name: "동물", tagId: 14 },
+    { name: "인물", tagId: 15 }
 ];
 Object.freeze(STYLES);
 Object.freeze(TAGS);


### PR DESCRIPTION
## 변경사항

### SaveDrawing.js

* 배열 STYLES 에 12번 DIY 태그 추가
* 배열 TAGS 에 15번 기타 태그 삭제, 풍경~인물 태그 tagId 수정

### CreateDrawing.js

* setPresetTagId()
  * preset === "cnn"일 때 dispatchPresetTagId() 인자 수정 (null -> 12)

    * SaveDrawing.js에서 아래와 같이 presetTagId를 사용하고 있길래 바꿨습니다
```javascript
{STYLES
  .filter(style => style.tagId == presetTagId)
(생략)
``` 