### PR TITLE
fix: cover nft storage strategy changes

### DIFF
--- a/src/components/KakaoDrawingShareButton.js
+++ b/src/components/KakaoDrawingShareButton.js
@@ -3,7 +3,7 @@ import React from "react";
 const KakaoDrawingShareButton = ({ drawing }) => {
 
     const sendShare = async () => {
-        const imageUrl = `https://ipfs.io/ipfs/${drawing.fileName}`;
+        const imageUrl = `https://${drawing.fileName}.ipfs.nftstorage.link`;
         const response = await fetch(imageUrl, { method: 'GET' });
         const blob = await response.blob();
         const { url: kakaoUploadUrl } = (await window.Kakao.Share.uploadImage({ file: [blob] }))

--- a/src/components/KakaoImageShareButton.js
+++ b/src/components/KakaoImageShareButton.js
@@ -3,7 +3,7 @@ import React from "react";
 const KakaoImageShareButton = ({ drawing }) => {
 
     const sendShare = async () => {
-        const imageUrl = `https://ipfs.io/ipfs/${drawing.fileName}`;
+        const imageUrl = `https://${drawing.fileName}.ipfs.nftstorage.link`;
         const response = await fetch(imageUrl, { method: 'GET' });
         const blob = await response.blob();
         const { url: kakaoUploadUrl } = (await window.Kakao.Share.uploadImage({ file: [blob] }))

--- a/src/routes/ApiTestPage.js
+++ b/src/routes/ApiTestPage.js
@@ -14,7 +14,7 @@ function ApiTestPage() {
 
     const downloadImage = async (fileName) => {
         try {
-            const imageUrl = `https://ipfs.io/ipfs/${fileName}`;
+            const imageUrl = `https://${fileName}.ipfs.nftstorage.link`;
             const response = await fetch(imageUrl, { method: 'GET' });
             const blob = await response.blob();
             const url = URL.createObjectURL(blob);

--- a/src/routes/DetailModal.js
+++ b/src/routes/DetailModal.js
@@ -27,7 +27,7 @@ function DetailModal({ drawing, handleDetailModalClose, openLoginAlert }) {
         clickDelete(drawing.id);
     }
 
-    const IMG = "https://ipfs.io/ipfs/" + drawing.fileName;
+    const IMG = `https://${drawing.fileName}.ipfs.nftstorage.link`;
 
     const [showLikeList, setShowLikeList] = useState(false);
     const handleshowLikeListOpen = () => { setShowLikeList(true); }

--- a/src/routes/Drawing.js
+++ b/src/routes/Drawing.js
@@ -13,7 +13,7 @@ function Drawing({ drawing, openLoginAlert }) {
     const [like, setLike] = useState(drawing.didHeart);
     const [bookmark, setBookmark] = useState(drawing.didScrap);
 
-    const image = "https://ipfs.io/ipfs/" + drawing.fileName;
+    const image = `https://${drawing.fileName}.ipfs.nftstorage.link`;
 
     function clickImg() {
         navigate(`${drawing.id}`);

--- a/src/routes/SaveDrawing.js
+++ b/src/routes/SaveDrawing.js
@@ -158,7 +158,7 @@ function SaveDrawing() {
                 <Grid item xs={12} md={6}>
                     <div className="uploadImage">
                         <Grow in={!isImageLoaded}><CircularProgress className="progress-bar" color="inherit" /></Grow>
-                        <Grow in={isImageLoaded}><img src={`https://ipfs.io/ipfs/${fileName}`} onLoad={imageLoaded} alt=""></img></Grow>
+                        <Grow in={isImageLoaded}><img src={`https://${drawing.fileName}.ipfs.nftstorage.link`} onLoad={imageLoaded} alt=""></img></Grow>
                     </div>
                 </Grid>
 

--- a/src/routes/UserDrawing.js
+++ b/src/routes/UserDrawing.js
@@ -9,7 +9,7 @@ function UserDrawing({ drawing, mine, clickDelete, clickScrap, openDetailModal, 
     const [like, setLike] = useState(drawing.didHeart);
     const [bookmark, setBookmark] = useState(drawing.didScrap); 
 
-    const img = "https://ipfs.io/ipfs/"+drawing.fileName;
+    const img = `https://${drawing.fileName}.ipfs.nftstorage.link`;
 
     function clickImg() {
         openDetailModal(drawing);

--- a/src/util/downloadImage.js
+++ b/src/util/downloadImage.js
@@ -1,5 +1,5 @@
 export const downloadImage = async (fileName) => {
-    const imageUrl = `https://ipfs.io/ipfs/${fileName}`;
+    const imageUrl = `https://${fileName}.ipfs.nftstorage.link`;
     const response = await fetch(imageUrl, { method: 'GET' });
     const blob = await response.blob();
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
# 문제 
##  원인
NFT Storage 이미지 관리 정책 변화
기존 https://ipfs.io/ipfs/{imageId} 주소가 -> https://{imageId}.ipfs.nftstorage.link 로 바뀜

## 해결 
링크 대체

### Before (엑박미슐간)
  <img width="1093" alt="image" src="https://user-images.githubusercontent.com/39221443/214524414-8a31ca9e-bbbc-44c9-ab21-5aa9c62a97fb.png">

### After (정상미슐간)
  <img width="1408" alt="image" src="https://user-images.githubusercontent.com/39221443/214524491-b28607ce-34fa-41ff-b941-ce2c18f4ab80.png">
